### PR TITLE
[Feature #133437767] Implement add bucketlist resource

### DIFF
--- a/app/auth/login.py
+++ b/app/auth/login.py
@@ -27,7 +27,7 @@ class Login(Resource):
         if not data:
             abort(
                 400,
-                message="No params passed. Kindly fill you username, email and password")
+                message="No params passed. Kindly fill you username and password")
         username = data['username']
         password = data['password']
 

--- a/app/bucketlist/bucketlists.py
+++ b/app/bucketlist/bucketlists.py
@@ -1,12 +1,73 @@
-from flask_restful import Resource
+import json
+import jwt
+from app import db
+from app.models.bucketlist_models import Bucketlists
+from config import Config
+from datetime import datetime
+from flask import jsonify, request
+from flask_restful import abort, Resource
+
+
+def decode_token(request):
+    token = request.headers.get('Authorization')
+    if not token:
+        abort(401, message="No Authorization token")
+    try:
+        payload = jwt.decode(token, Config.SECRET_KEY)
+    except jwt.DecodeError:
+        abort(401, message='Token is invalid')
+    except jwt.ExpiredSignature:
+        abort(401, message="Token has expired.Login to generate another token")
+
+    return payload['sub']
 
 
 class Bucketlist(Resource):
     def get(self):
-        pass
+        """ List all bucketlists created by the user"""
+        result = {}
+        user_id = decode_token(request)
+        bucketlists = Bucketlists.query.filter_by(creator_id=user_id).all()
+        if not len(bucketlists):
+            abort(400, message="User does not have bucketlists")
+        for bucketlist in bucketlists:
+            result.update({
+                bucketlist.id: {
+                    "name": bucketlist.name,
+                    "description": bucketlist.description,
+                    "creator": bucketlist.creator.username
+                }})
+        return jsonify(result)
 
     def post(self):
-        pass
+        user_id = decode_token(request)
+        data = json.loads(request.get_data(as_text=True))
+        if not data:
+            abort(
+                400,
+                message="No params passed.Kindly fill the name and description.")
+        name = data['name']
+        description = data['description']
+        creator_id = user_id
+
+        bucketlist = Bucketlists.query.filter_by(
+            name=name, creator_id=user_id).first()
+        if bucketlist:
+            abort(400, message="{} bucketlist already exists".format(
+                bucketlist.name))
+        try:
+            new_bucketlist = Bucketlists(
+                name=name,
+                description=description,
+                time_created=datetime.utcnow(),
+                creator_id=creator_id
+            )
+            db.session.add(new_bucketlist)
+            db.session.commit()
+            return jsonify({
+                'message': "{} bucketlist created successfully".format(name)})
+        except Exception:
+            abort(500, message="Bucketlist not created")
 
 
 class OneBucketlist(Resource):

--- a/app/bucketlist/test_bucketlist.py
+++ b/app/bucketlist/test_bucketlist.py
@@ -28,22 +28,28 @@ class BucketlistTest(GlobalTestCase):
         self.logged_in_user = Users.query.filter_by(username='Loice').first()
 
     def test_bucketlist_endpoint(self):
-        response = self.client.get('/bucketlists/')
+        response = self.client.get('/bucketlists/',
+                                   headers=self.token)
         self.assert_200(response)
 
-        response = self.client.post('/bucketlists/')
+        response = self.client.post('/bucketlists/',
+                                    headers=self.token)
         self.assert_200(response)
 
-        response = self.client.get('/bucketlists/1')
+        response = self.client.get('/bucketlists/1',
+                                   headers=self.token)
         self.assert_200(response)
 
-        response = self.client.put('/bucketlists/1')
+        response = self.client.put('/bucketlists/1',
+                                   headers=self.token)
         self.assert_200(response)
 
-        response = self.client.delete('/bucketlists/1')
+        response = self.client.delete('/bucketlists/1',
+                                      headers=self.token)
         self.assert_200(response)
 
-        response = self.client.get('/bucketlists?q=bucket1')
+        response = self.client.get('/bucketlists?q=bucket1',
+                                   headers=self.token)
         self.assert_200(response)
 
     def test_can_create_bucketlist(self):


### PR DESCRIPTION
## What does this PR do?

Implement Bucketlist API to view all bucket lists related to a user and to add a bucket list

## Description of task to be completed:

Implement API to add a bucketlist and to view all bucketlists
## How should this be manually tested?

Navigate to the bucketlist app directory
`cd bucket-list-application-api`
Run `python run.py runserver`
Go to `Postman` and input the url `http://127.0.0.1:5000/api/v1/auth/bucketlists/` 
Input the authorization token generated after login
Go to `Body` and input `{"name":"Christmas plans","description":"Activities for 2016 christmas holiday"}` as raw.

## What are the relevant pivotal tracker stories?
[#133437767 ](https://www.pivotaltracker.com/story/show/133437767) 