### PR TITLE
[Feature #133437789] Implement Single bucketlist API to view,edit,delete

### DIFF
--- a/app/bucketlist/bucketlists.py
+++ b/app/bucketlist/bucketlists.py
@@ -50,8 +50,12 @@ class Bucketlist(Resource):
         description = data['description']
         creator_id = user_id
 
+        if not name:
+            abort(400, message="Name cannot be empty")
+
         bucketlist = Bucketlists.query.filter_by(
-            name=name, creator_id=user_id).first()
+            name=name,
+            creator_id=user_id).first()
         if bucketlist:
             abort(400, message="{} bucketlist already exists".format(
                 bucketlist.name))
@@ -72,16 +76,70 @@ class Bucketlist(Resource):
 
 class OneBucketlist(Resource):
     def get(self, bucketlist_id):
-        pass
-
-    def post(self, bucketlist_id):
-        pass
+        result = {}
+        user_id = decode_token(request)
+        single_bucketlist = Bucketlists.query.filter_by(
+            creator_id=user_id,
+            id=bucketlist_id).first()
+        if not single_bucketlist:
+            abort(400, message="No bucketlist matching the id {}".format(
+                bucketlist_id))
+        result.update({
+            single_bucketlist.id: {
+                "name": single_bucketlist.name,
+                "description": single_bucketlist.description,
+                "creator": single_bucketlist.creator.username
+            }})
+        return jsonify(result)
 
     def put(self, bucketlist_id):
-        pass
+        user_id = decode_token(request)
+        if bucketlist_id is None:
+            abort(400, message="Missing bucketlist ID")
+        data = json.loads(request.get_data(as_text=True))
+        if not data:
+            abort(
+                400,
+                message="No params passed.Kindly fill the name and description.")
+
+        single_bucketlist = Bucketlists.query.filter_by(
+            creator_id=user_id,
+            id=bucketlist_id).first()
+        print (single_bucketlist)
+        if not single_bucketlist:
+            abort(400, message="No bucketlist matching the id {}".format(
+                bucketlist_id))
+
+        try:
+            if 'name' in data.keys():
+                single_bucketlist.name = data['name']
+            if 'description' in data.keys():
+                single_bucketlist.description = data['description']
+            db.session.add(single_bucketlist)
+            db.session.commit()
+            return jsonify({
+                'message': "{} bucketlist updated successfully".format(single_bucketlist.name)})
+        except Exception:
+            abort(500, message="Bucketlist not updated")
 
     def delete(self, bucketlist_id):
-        pass
+        user_id = decode_token(request)
+        if bucketlist_id is None:
+            abort(400, message="Missing bucketlist ID")
+        single_bucketlist = Bucketlists.query.filter_by(
+            creator_id=user_id,
+            id=bucketlist_id).first()
+        if not single_bucketlist:
+            abort(400, message="No bucketlist matching the id {}".format(
+                bucketlist_id))
+        try:
+            db.session.delete(single_bucketlist)
+            db.session.commit()
+            return jsonify({
+                'message': "{} bucketlist deleted successfully".format(
+                    single_bucketlist.name)})
+        except Exception:
+            abort(500, message="Bucketlist not deleted")
 
 
 class SearchBucketlist(Resource):


### PR DESCRIPTION
## What does this PR do?

Implement Bucketlist API to view, edit and delete a single bucketlist

## Description of task to be completed:

Implement Bucketlist API to view, edit and delete a single bucketlist

## How should this be manually tested?

Navigate to the bucketlist app directory
`cd bucket-list-application-api`
Run `python run.py runserver`
Go to `Postman` and input the url `http://127.0.0.1:5000/api/v1/auth/bucketlists/1/` 
Input the authorization token generated after login
To view a single bucketlist, use the `GET` method.
To edit the bucketlist, use the `PUT` method; in the body, pass `{"name":"Christmas 2016"}`
To delete the bucketlist, use the `DELETE` method.

## What are the relevant pivotal tracker stories?
[#133437789 ](https://www.pivotaltracker.com/story/show/133437789) 
[#133437803](https://www.pivotaltracker.com/story/show/133437803)